### PR TITLE
fix: add types/ws

### DIFF
--- a/unity-mcp-server/package.json
+++ b/unity-mcp-server/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.24",
+    "@types/ws": "^8.18.0",
     "typescript": "^5.3.3"
   }
 }


### PR DESCRIPTION
## Summary

Add `types/ws` to avoid error.

## Before 

```ps
PS C:\Users\hiroga\Documents\GitHub\UnityMCP\unity-mcp-server> npm i

> UnityMCP@0.1.0 prepare
> npm run build


> UnityMCP@0.1.0 build
> tsc && node --input-type=module -e "import { chmod } from 'fs/promises'; await chmod('build/index.js', '755');"

src/index.ts:10:44 - error TS7016: Could not find a declaration file for module 'ws'. 'C:/Users/hiroga/Documents/GitHub/UnityMCP/unity-mcp-server/node_modules/ws/wrapper.mjs' implicitly has an 'any' type.
  Try `npm i --save-dev @types/ws` if it exists or add a new declaration (.d.ts) file containing `declare module 'ws';`     

10 import { WebSocketServer, WebSocket } from 'ws';
                                              ~~~~

src/index.ts:85:32 - error TS7006: Parameter 'error' implicitly has an 'any' type.

85     this.wsServer.on('error', (error) => {
                                  ~~~~~

src/index.ts:103:23 - error TS7006: Parameter 'error' implicitly has an 'any' type.

103       ws.on('error', (error) => {
                          ~~~~~


Found 3 errors in the same file, starting at: src/index.ts:10

npm notice 
npm notice New major version of npm available! 10.2.4 -> 11.2.0
npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.2.0
npm notice Run npm install -g npm@11.2.0 to update!
npm notice
npm ERR! code 2
npm ERR! path C:\Users\hiroga\Documents\GitHub\UnityMCP\unity-mcp-server
npm ERR! command failed
npm ERR! command C:\WINDOWS\system32\cmd.exe /d /s /c npm run build

npm ERR! A complete log of this run can be found in: C:\Users\hiroga\AppData\Local\npm-cache\_logs\2025-03-18T12_40_44_699Z-debug-0.log
```

# After

```ps
PS C:\Users\hiroga\Documents\GitHub\UnityMCP\unity-mcp-server> npm i --save-dev @types/ws

added 1 package, and audited 20 packages in 625ms

1 package is looking for funding
  run `npm fund` for details

found 0 vulnerabilities
PS C:\Users\hiroga\Documents\GitHub\UnityMCP\unity-mcp-server> npm run build

> UnityMCP@0.1.0 build
> tsc && node --input-type=module -e "import { chmod } from 'fs/promises'; await chmod('build/index.js', '755');"
```
